### PR TITLE
Fixes call to monolog error handler

### DIFF
--- a/src/MonologErrorHandler.php
+++ b/src/MonologErrorHandler.php
@@ -37,7 +37,8 @@ class MonologErrorHandler extends CErrorHandler
      */
     protected function handleError($event)
     {
-        $this->errorHandler->handleError($event->code, $event->message, $event->file, $event->line, $event->params);
+        $context = is_array($event->params) ? $event->params : [$event->params];
+        $this->errorHandler->handleError($event->code, $event->message, $event->file, $event->line, $context);
         parent::handleError($event);
     }
 }


### PR DESCRIPTION
The context param of handleError() should be always an array